### PR TITLE
Update the IDE version to 2025.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ val downloadJDKTasks = arches.associateWith { arch ->
 
 val nativesProperties: Map<String, String> = Utils.loadProperties(configDir.file("natives.properties"))
 
-for (arch in Arch.values()) {
+for (arch in Arch.entries) {
     val isCross = arch != Arch.current()
     val archName = arch.normalize()
     fun findArchProperty(name: String): String? = findProperty("$arch.$name")?.toString()
@@ -99,7 +99,7 @@ for (arch in Arch.values()) {
 
 val allProductProperties: Map<String, String> = Utils.loadProperties(configDir.file("product.properties"))
 
-for (product in Product.values()) {
+for (product in Product.entries) {
     val productProperties = product.resolveProperties(allProductProperties)
 
     val productVersion = productProperties["version"]
@@ -113,7 +113,7 @@ for (product in Product.values()) {
         inputs.properties(productProperties)
 
         src(product.getDownloadLink(productVersion, productBaseArch))
-        dest(downloadDir.dir("ide"))
+        dest(downloadDir.dir("ide").file(product.getFileNameBase(productVersion, productBaseArch) + ".tar.gz"))
         overwrite(false)
     }
 

--- a/buildSrc/src/main/java/org/glavo/build/Product.java
+++ b/buildSrc/src/main/java/org/glavo/build/Product.java
@@ -20,8 +20,8 @@ import java.util.Locale;
 import java.util.Map;
 
 public enum Product {
-    IDEA_IC("IC"),
-    IDEA_IU("IU"),
+    IDEA("IU"),
+    IDEA_COMMUNITY("IC"),
     PYCHARM("PY"),
     PYCHARM_COMMUNITY("PC"),
     WEBSTORM("WS"),
@@ -39,7 +39,7 @@ public enum Product {
     }
 
     public boolean isOpenSource() {
-        return this == IDEA_IC || this == PYCHARM_COMMUNITY;
+        return this == IDEA_COMMUNITY || this == PYCHARM_COMMUNITY;
     }
 
     public String getProductCode() {
@@ -48,8 +48,8 @@ public enum Product {
 
     private String getFileNamePrefix() {
         return switch (this) {
-            case IDEA_IC -> "ideaIC";
-            case IDEA_IU -> "ideaIU";
+            case IDEA -> "idea";
+            case IDEA_COMMUNITY -> "ideaIC";
             case PYCHARM -> "pycharm";
             case PYCHARM_COMMUNITY -> "pycharm-community";
             case WEBSTORM -> "WebStorm";
@@ -70,22 +70,35 @@ public enum Product {
     }
 
     public String getDownloadLink(String version, Arch arch) {
-        String downloadLinkPrefix = switch (this) {
-            case IDEA_IC, IDEA_IU -> "idea";
-            case PYCHARM, PYCHARM_COMMUNITY -> "python";
-            case WEBSTORM -> "webstorm";
-            case CLION -> "cpp";
-            case GOLAND -> "go";
-            case RUSTROVER -> "rustrover";
-            case RUBYMINE -> "ruby";
-            case PHPSTORM -> "webide";
-        };
-        return "https://download.jetbrains.com/%s/%s.tar.gz".formatted(downloadLinkPrefix, getFileNameBase(version, arch));
+        if (this == IDEA_COMMUNITY || this == PYCHARM_COMMUNITY) {
+            String githubName = switch (this) {
+                case IDEA_COMMUNITY -> "idea";
+                case PYCHARM_COMMUNITY -> "pycharm";
+                default -> throw new AssertionError("Unreachable code");
+            };
+
+            return "https://github.com/JetBrains/intellij-community/releases/download/%1$s%%2F%2$s/%1$s-%2$s-%3$s.tar.gz"
+                    .formatted(githubName, version, arch.normalize());
+        } else {
+            String downloadLinkPrefix = switch (this) {
+                //noinspection DataFlowIssue
+                case IDEA_COMMUNITY, IDEA -> "idea";
+                //noinspection DataFlowIssue
+                case PYCHARM, PYCHARM_COMMUNITY -> "python";
+                case WEBSTORM -> "webstorm";
+                case CLION -> "cpp";
+                case GOLAND -> "go";
+                case RUSTROVER -> "rustrover";
+                case RUBYMINE -> "ruby";
+                case PHPSTORM -> "webide";
+            };
+            return "https://download.jetbrains.com/%s/%s.tar.gz".formatted(downloadLinkPrefix, getFileNameBase(version, arch));
+        }
     }
 
     public String getLauncherName() {
         return switch (this) {
-            case IDEA_IC, IDEA_IU -> "idea";
+            case IDEA_COMMUNITY, IDEA -> "idea";
             case PYCHARM, PYCHARM_COMMUNITY -> "pycharm";
             case WEBSTORM -> "webstorm";
             case CLION -> "clion";
@@ -99,8 +112,8 @@ public enum Product {
     public String getPackageName() {
         // https://github.com/JonasGroeger/jetbrains-ppa
         return switch (this) {
-            case IDEA_IC -> "intellij-idea-community";
-            case IDEA_IU -> "intellij-idea-ultimate";
+            case IDEA -> "intellij-idea-ultimate";
+            case IDEA_COMMUNITY -> "intellij-idea-community";
             case PYCHARM -> "pycharm";
             case PYCHARM_COMMUNITY -> "pycharm-community";
             case WEBSTORM -> "webstorm";
@@ -114,8 +127,8 @@ public enum Product {
 
     public String getFullName() {
         return switch (this) {
-            case IDEA_IC -> "IntelliJ IDEA Community Edition";
-            case IDEA_IU -> "IntelliJ IDEA Ultimate";
+            case IDEA -> "IntelliJ IDEA Ultimate";
+            case IDEA_COMMUNITY -> "IntelliJ IDEA Community Edition";
             case PYCHARM -> "PyCharm";
             case PYCHARM_COMMUNITY -> "PyCharm Community";
             case WEBSTORM -> "WebStorm";
@@ -129,8 +142,8 @@ public enum Product {
 
     public String getDescription() {
         return switch (this) {
-            case IDEA_IC -> "The IDE for Java and Kotlin enthusiasts";
-            case IDEA_IU -> "The IDE for Pro Java and Kotlin developers";
+            case IDEA -> "The IDE for Pro Java and Kotlin developers";
+            case IDEA_COMMUNITY -> "The IDE for Java and Kotlin enthusiasts";
             case PYCHARM -> "The only Python IDE you need";
             case PYCHARM_COMMUNITY -> "The pure Python IDE";
             case WEBSTORM -> "A JavaScript and TypeScript IDE";
@@ -144,7 +157,7 @@ public enum Product {
 
     public long getPriority() {
         return switch (this) {
-            case IDEA_IC, PYCHARM_COMMUNITY -> 50L;
+            case IDEA_COMMUNITY, PYCHARM_COMMUNITY -> 50L;
             default -> 100L;
         };
     }
@@ -156,7 +169,7 @@ public enum Product {
 
     public String getDesktopKeywords() {
         return "jetbrains;" + (switch (this) {
-            case IDEA_IC, IDEA_IU -> "intellij;idea;java;kotlin;scala;";
+            case IDEA_COMMUNITY, IDEA -> "intellij;idea;java;kotlin;scala;";
             case PYCHARM, PYCHARM_COMMUNITY -> "python;";
             case WEBSTORM -> "js;javascript;typescript;html;";
             case CLION -> "cpp;";

--- a/buildSrc/src/main/java/org/glavo/build/tasks/CreateDeb.java
+++ b/buildSrc/src/main/java/org/glavo/build/tasks/CreateDeb.java
@@ -208,7 +208,7 @@ public abstract class CreateDeb extends DefaultTask {
 
         // Older packages create a script in /usr/bin instead of using update-alternatives
         // We should make sure old packages are removed
-        if (product == Product.IDEA_IC || product == Product.IDEA_IU) {
+        if (product == Product.IDEA_COMMUNITY || product == Product.IDEA) {
             lines.add("Replaces: intellij-idea-ce-multiarch");
             lines.add("Conflicts: intellij-idea-ce-multiarch");
         } else if (product == Product.PYCHARM_COMMUNITY || product == Product.PYCHARM) {

--- a/config/product.properties
+++ b/config/product.properties
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-default.version=2025.2
+default.version=2025.3
 default.version.additional=0
 default.baseArch=aarch64
-
-pc.version=2025.2.0.1
-py.version=2025.2.0.1

--- a/config/product.properties
+++ b/config/product.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-default.version=2025.3
+default.version=2025.3.1
 default.version.additional=0
 default.baseArch=aarch64

--- a/template/README.md.template
+++ b/template/README.md.template
@@ -42,12 +42,6 @@ We provide pre-built distributions for the IDEs that can be redistributed.
 As for other IDEs, we are not allowed to redistribute them.
 Please [build them yourself](#Building).
 
-> [!NOTE]
-> Since [PyCharm Community has been replaced by PyCharm](https://blog.jetbrains.com/pycharm/2025/04/unified-pycharm/), which is not allowed to be redistributed,
-> we will no longer provide pre-built files for PyCharm in the future.
-> 
-> If you want to continue using PyCharm, please build it yourself according to the following documentation.
-
 ## Building
 
 The work of this project is to download the official IDE distribution,


### PR DESCRIPTION
It appears that starting with 2025.2, the JetBrains IDE depends on [skiko](https://github.com/JetBrains/skiko). We need to investigate where Skiko is being used and whether we need to adapt it for skiko.